### PR TITLE
update otel dependencies to 0.19 spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ddtrace"
-version = "0.0.7"
+version = "0.1.0"
 authors = ["David Steiner <david_j_steiner@yahoo.co.nz", "Fergus Strangways-Dixon <fergusdixon101@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -17,15 +17,15 @@ axum = ["dep:axum", "dep:tokio", "dep:axum-tracing-opentelemetry"]
 
 [dependencies]
 axum = { version = "^0.6.10", optional = true }
-axum-tracing-opentelemetry = { version = "^0.10.0", optional = true }
+axum-tracing-opentelemetry = { version = "^0.11.0", optional = true }
 chrono = "^0.4.24"
-opentelemetry = { version = "^0.18.0", features = ["rt-tokio"] }
-opentelemetry-datadog = "^0.6.0"
-opentelemetry-otlp = { version = "^0.11.0" }
+opentelemetry = { version = "^0.19.0", features = ["rt-tokio"] }
+opentelemetry-datadog = "^0.7.0"
+opentelemetry-otlp = { version = "^0.12.0" }
 serde = { version = "^1.0.156", features = ["derive"] }
 serde_json = "^1.0.95"
 tokio = { version = "^1.26.0", features = ["signal"], optional = true }
 tracing = "^0.1.37"
-tracing-opentelemetry = "^0.18.0"
+tracing-opentelemetry = "^0.19.0"
 tracing-serde = "^0.1.3"
 tracing-subscriber = { version = "^0.3.16", features = ["env-filter", "json"] }


### PR DESCRIPTION
Semi-related to https://github.com/davidB/tracing-opentelemetry-instrumentation-sdk/issues/78